### PR TITLE
[PR] UI improvement - add user deck on navbar

### DIFF
--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -25,6 +25,7 @@ const GameBoard: React.FC = () => {
   const hints = [...rawHints].sort((a, b) => parseInt(b.difficulty) - parseInt(a.difficulty));
   const userId = useSelector((state: { user: { userId: string } }) => state.user.userId);
   const gameId = useSelector((state: { game: { gameId: string } }) => state.game.gameId);
+  const ownerId = useSelector((state: { game: { ownerId: string } }) => state.game.ownerId);
   const gameMode = useSelector((state: { game: { modeType: string } }) => state.game.modeType);
   const initialScoreBoard = useSelector((state: { game: { scoreBoard: Map<string, number> } }) => state.game.scoreBoard);
   const restTime = useSelector((state: { game: { time: string } }) => state.game.time);
@@ -100,6 +101,14 @@ const GameBoard: React.FC = () => {
             setGameEnded(true);
             setEndMessage(data);
             setTimeout(() => {
+              if (String(userId) === String(ownerId)) {
+                apiService.put(`/save/${gameId}`, {})
+                  .then()
+                  .catch((error) => {
+                    alert(`Error saving game: ${error.message}`);
+                    router.push("/game");
+                  });
+              }
               router.push(`/game/results/${gameId}`);
             }, 1000);
           } catch (err) {

--- a/app/game/[id]/page.tsx
+++ b/app/game/[id]/page.tsx
@@ -136,7 +136,7 @@ const GameBoard: React.FC = () => {
     return () => {
       client.deactivate();
     };
-  }, []);
+  }, [apiService, dispatch, gameId, initialScoreBoard, ownerId, router, userId]);
 
   const handleFinishGame = async () => {
     try {

--- a/app/game/page.tsx
+++ b/app/game/page.tsx
@@ -85,7 +85,7 @@ const Dashboard: React.FC = () => {
     return () => {
       client.deactivate();
     };
-  }, [gameId]);
+  }, [gameId, userId, dispatch]);
 
   useEffect(() => {
     if (countDownStart === null) return;
@@ -111,7 +111,7 @@ const Dashboard: React.FC = () => {
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [countDownStart]);
+  }, [countDownStart, gameId, router]);
 
   const handleStart = async () => {
     const newGame: Game = {

--- a/app/game/results/[id]/page.tsx
+++ b/app/game/results/[id]/page.tsx
@@ -18,12 +18,6 @@ const Results = () => {
   const username = useSelector(
     (state: { user: { username: string } }) => state.user.username
   );
-  const gameId = useSelector(
-    (state: { game: { gameId: string } }) => state.game.gameId
-  );
-  const ownerId = useSelector(
-    (state: { game: { ownerId: string } }) => state.game.ownerId
-  );
   const userId = useSelector(
     (state: { user: { userId: string } }) => state.user.userId
   );

--- a/app/game/results/[id]/page.tsx
+++ b/app/game/results/[id]/page.tsx
@@ -1,14 +1,17 @@
 "use client";
 
 import React from "react";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
 import { useRouter } from 'next/navigation';
 import styles from "@/styles/results.module.css";
 import { useApi } from "@/hooks/useApi";
+import { User } from "@/types/user";
+import { updateUserInfo } from "@/userSlice";
 
 const Results = () => {
   const router = useRouter();
   const apiService = useApi();
+  const dispatch = useDispatch();
   const scoreBoard = useSelector(
     (state: { game: { scoreBoard?: Map<string, number> } }) => state.game.scoreBoard ?? {}
   );
@@ -31,15 +34,30 @@ const Results = () => {
   const entries = Object.entries(scoreBoard) as [string, number][];
 
   const handleBackToLobby = async () => {
-    if (String(userId) === String(ownerId)) {
-      apiService.put(`/save/${gameId}`, {})
-        .then()
-        .catch((error) => {
-          alert(`Error saving game: ${error.message}`);
-          router.push("/game");
-        });
-    }
+    // if (String(userId) === String(ownerId)) {
+    //   apiService.put(`/save/${gameId}`, {})
+    //     .then()
+    //     .catch((error) => {
+    //       alert(`Error saving game: ${error.message}`);
+    //       router.push("/game");
+    //     });
+    // }
     if (gameMode === "combat") {
+      try {
+        const response: User = await apiService.get<User>(`/users/${userId}`);
+        dispatch(updateUserInfo({
+          username: response.username ?? "",
+          avatar: response.avatar ?? "",
+          level: Number(response.level) / 100,
+        }));
+      } catch (error) {
+        if (error instanceof Error) {
+          alert(`Something went wrong while fetching user:\n${error.message}`);
+          router.push("/game");
+        } else {
+          console.error("An unknown error occurred while fetching user.");
+        }
+      }
       router.push("/lobby");
     } else {
       router.push("/game");

--- a/app/game/results/page.tsx
+++ b/app/game/results/page.tsx
@@ -69,10 +69,6 @@ const Results = () => {
 
   const gameId = "dummy-123"; // Replace with actual router param in production
 
-  useEffect(() => {
-    fetchGameResults(gameId);
-  }, [gameId]);
-
   const fetchGameResults = async (id: string) => {
     setLoading(true);
     try {
@@ -99,6 +95,10 @@ const Results = () => {
       setLoading(false);
     }
   };
+
+  useEffect(() => {
+    fetchGameResults(gameId);
+  }, [gameId, fetchGameResults]);
 
   const renderContent = () => {
     if (!gameData) return null;

--- a/app/game/start/[id]/page.tsx
+++ b/app/game/start/[id]/page.tsx
@@ -138,7 +138,7 @@ const GameStart = () => {
     return () => {
       client.deactivate();
     };
-  }, [gameId]);
+  }, [gameId, apiService, dispatch, router, gameCode]);
 
   useEffect(() => {
     if (countDownStart === null) return;
@@ -164,7 +164,7 @@ const GameStart = () => {
     }, 1000);
 
     return () => clearInterval(interval);
-  }, [countDownStart]);
+  }, [countDownStart, router, gameId]);
 
   const handleExitGame = async () => {
     try {

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -83,7 +83,7 @@ const GameHistoryPage: React.FC = () => {
     };
 
     fetchHistory();
-  }, []);
+  }, [apiService, userId]);
 
 
   const filtered = Array.from(history.entries()).filter(([, entry]) => {

--- a/app/hooks/authWrapper.tsx
+++ b/app/hooks/authWrapper.tsx
@@ -54,7 +54,7 @@ export default function AuthWrapper({ children }: { children: React.ReactNode })
     };
 
     verifyToken();
-  }, [token, pathname]);
+  }, [token, pathname, shouldAuth, apiService]);
 
   useEffect(() => {
     if (shouldAuth && authChecked && authFailed) {

--- a/app/hooks/interactiveMap.tsx
+++ b/app/hooks/interactiveMap.tsx
@@ -189,7 +189,7 @@ const InteractiveMap: React.FC = () => {
         }
       })
       .catch(error => console.error("Load failed: ", error));
-  }, []);
+  }, [apiService, dispatch, gameId, userId]);
 
   useEffect(() => {
     hintUsageRef.current = hintUsingNumber;

--- a/app/leaderboard/page.tsx
+++ b/app/leaderboard/page.tsx
@@ -28,7 +28,7 @@ const LeaderboardPage: React.FC = () => {
     };
 
     fetchLeaderboard();
-  }, []);
+  }, [apiService]);
 
   // const paginated = filtered.slice(0, currentPage * itemsPerPage);
   // const hasMore = paginatedEntries.length < entries.length;

--- a/app/lobby/page.tsx
+++ b/app/lobby/page.tsx
@@ -61,7 +61,7 @@ const Lobby: React.FC = () => {
     return () => {
       client.deactivate();
     };
-  }, []);
+  }, [apiService, userId, start]);
 
   useEffect(() => {
     setPaginatedGames(games.slice((currentPage - 1) * itemsPerPage, currentPage * itemsPerPage));

--- a/app/navbar.tsx
+++ b/app/navbar.tsx
@@ -1,105 +1,226 @@
-"use client"; // ✅ Mark this as a Client Component
+"use client";
 
 import Image from "next/image";
 import Link from "next/link";
-import { useSelector } from "react-redux"; // Import Redux hooks
-import { UserOutlined, HistoryOutlined, TrophyOutlined, LoginOutlined, UserAddOutlined, LogoutOutlined } from "@ant-design/icons";
-import { Button, Tooltip } from "antd";
-import { RootState } from "./"; // Import RootState to type the useSelector hook
-import { useLogout } from "@/utils/useLogout"; // Import the logout function
+import { useSelector } from "react-redux";
+import { TrophyOutlined, LogoutOutlined, UserOutlined, HistoryOutlined, BookOutlined } from "@ant-design/icons";
+import { Avatar, Dropdown, Tooltip } from "antd";
+import { RootState } from "./";
+import { useLogout } from "@/utils/useLogout";
+import { useState } from "react";
 
 export default function Navbar() {
-  // Use Redux state to check if the user is logged in
-  const isLoggedIn = useSelector((state: RootState) => state.user.isLoggedIn);
+  const username = useSelector((state: RootState) => state.user.username);
+  const avatar = useSelector((state: RootState) => state.user.avatar);
+  const level = useSelector((state: RootState) => state.user.level);
+  const logout = useLogout();
 
-  // Get the logout function
-  const handleLogoutRedux = useLogout();
+  const xp = (level ?? 0) * 100;
+  const [dropdownOpen, setDropdownOpen] = useState(false);
+  const [hovered, setHovered] = useState<string | null>(null);
+
+  let barPercent = 0;
+  let barColor = "";
+  if (xp < 5000) {
+    barPercent = (xp / 5000) * 100;
+    barColor = "linear-gradient(90deg, #73d13d, #52c41a)"; // MapAmateur
+  } else if (xp < 10000) {
+    barPercent = ((xp - 5000) / 5000) * 100;
+    barColor = "linear-gradient(90deg, #40a9ff, #1890ff)"; // MapExpert
+  } else {
+    barPercent = ((xp - 10000) / 5000) * 100;
+    barColor = "linear-gradient(90deg, #ffd700, #f4e542)"; // MapMaster
+  }
+
+  const title = xp >= 10000
+    ? "MapMaster"
+    : xp >= 5000
+      ? "MapExpert"
+      : "MapAmateur";
+
+  const dropdownContent = (
+    <div
+      style={{
+        width: 200,
+        background: "#002c4d",
+        color: "#fff",
+        borderRadius: 12,
+        padding: 16,
+        boxShadow: "0 8px 24px rgba(0, 0, 0, 0.45)",
+        backdropFilter: "blur(4px)",
+      }}
+    >
+      {/* menu */}
+      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
+        <Link
+          href="/users/profile"
+          onClick={() => setDropdownOpen(false)}
+          style={{ ...menuItemStyle, backgroundColor: hovered === "profile" ? "#014b7d" : "transparent" }}
+          onMouseEnter={() => setHovered("profile")}
+          onMouseLeave={() => setHovered(null)}
+        >
+          <UserOutlined /> Profile
+        </Link>
+        <Link
+          href="/history"
+          onClick={() => setDropdownOpen(false)}
+          style={{ ...menuItemStyle, backgroundColor: hovered === "history" ? "#014b7d" : "transparent" }}
+          onMouseEnter={() => setHovered("history")}
+          onMouseLeave={() => setHovered(null)}
+        >
+          <HistoryOutlined /> Game History
+        </Link>
+        <Link
+          href="/statistics"
+          onClick={() => setDropdownOpen(false)}
+          style={{ ...menuItemStyle, backgroundColor: hovered === "statistics" ? "#014b7d" : "transparent" }}
+          onMouseEnter={() => setHovered("statistics")}
+          onMouseLeave={() => setHovered(null)}
+        >
+          <BookOutlined /> Statistics
+        </Link>
+        <div
+          onClick={() => { logout(); setDropdownOpen(false); }}
+          style={{ ...menuItemStyle, color: "#ff4d4f", backgroundColor: hovered === "logout" ? "#444" : "transparent" }}
+          onMouseEnter={() => setHovered("logout")}
+          onMouseLeave={() => setHovered(null)}
+        >
+          <LogoutOutlined /> Logout
+        </div>
+      </div>
+    </div>
+  );
 
   return (
-    <nav className="navbar">
+    <nav
+      className="navbar"
+      style={{
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        padding: "10px 20px",
+        backgroundColor: "#002140",
+      }}
+    >
       {/* Logo */}
-      <Tooltip title="Home">
-        <Link href="/game">
-          <Image src="/mapmaster-logo.png" alt="Home" width={70} height={60} />
-        </Link>
-      </Tooltip>
+      <Link href="/game">
+        <Image src="/mapmaster-logo.png" alt="Home" width={70} height={60} />
+      </Link>
 
-      {/* Right-side Icons */}
-      <div style={{ display: "flex", gap: "20px", alignItems: "center" }}>
-        {isLoggedIn ? (
-          <>
-            <Tooltip title="Profile">
-              <Link href="/users/profile">
-                <UserOutlined
-                  style={{ fontSize: "24px", color: "#fff", cursor: "pointer" }}
-                  aria-label="Profile"
-                />
-              </Link>
-            </Tooltip>
+      <div style={{ display: "flex", alignItems: "center", gap: 20 }}>
+        {/* Leaderboard */}
+        <Tooltip title="Leaderboard">
+          <Link href="/leaderboard">
+            <TrophyOutlined
+              style={{ fontSize: "24px", color: "#fff", cursor: "pointer" }}
+              aria-label="Leaderboard"
+            />
+          </Link>
+        </Tooltip>
 
-            <Tooltip title="Game History">
-              <Link href="/history">
-                <HistoryOutlined
-                  style={{ fontSize: "24px", color: "#fff", cursor: "pointer" }}
-                  aria-label="Game History"
-                />
-              </Link>
-            </Tooltip>
-
-            <Tooltip title="Leaderboard">
-              <Link href="/leaderboard">
-                <TrophyOutlined
-                  style={{ fontSize: "24px", color: "#fff", cursor: "pointer" }}
-                  aria-label="Leaderboard"
-                />
-              </Link>
-            </Tooltip>
-
-            {/* <Tooltip title="Statistics">
-              <Link href="/statistics">
-                <BookOutlined
-                  style={{ fontSize: "24px", color: "#fff", cursor: "pointer" }}
-                  aria-label="Statistics"
-                />
-              </Link>
-            </Tooltip> */}
-
-            <Tooltip title="Logout">
-              <Button
-                type="primary"
-                danger
-                icon={<LogoutOutlined />}
-                onClick={handleLogoutRedux} // Use handleLogoutRedux for logging out
+        {/* Dropdown Trigger */}
+        <Dropdown
+          dropdownRender={() => dropdownContent}
+          trigger={["click"]}
+          placement="bottomRight"
+          arrow={false}
+          open={dropdownOpen}
+          onOpenChange={(open) => setDropdownOpen(open)}
+        >
+          <div
+            style={{
+              display: "flex",
+              alignItems: "center",
+              gap: 10,
+              backgroundColor: "transparent",
+              padding: "8px 12px",
+              borderRadius: 10,
+              color: "#fff",
+              minWidth: 200,
+              cursor: "pointer",
+            }}
+          >
+            <Avatar src={avatar || "/avatar_1.png"} size="large" />
+            <div style={{ flex: 1 }}>
+              <div style={{ fontWeight: "bold", fontSize: 14, marginBottom: 4 }}>{username || "Guest"}</div>
+              <div style={{ position: "relative", width: "100%", marginBottom: 4 }}>
+                <div
+                  style={{
+                    backgroundColor: "#333",
+                    borderRadius: 100,
+                    height: 16,
+                    width: "100%",
+                    overflow: "hidden",
+                    boxShadow: "inset 0 0 4px rgba(0,0,0,0.5)",
+                    position: "relative",
+                  }}
+                >
+                  <div
+                    style={{
+                      height: "100%",
+                      width: `${Math.min(barPercent, 100)}%`,
+                      background: barColor,
+                      transition: "width 0.3s ease-in-out",
+                      position: "absolute",
+                      top: 0,
+                      left: 0,
+                      zIndex: 1,
+                    }}
+                  />
+                  <div
+                    style={{
+                      position: "relative",
+                      zIndex: 2,
+                      color: "#fff",
+                      textAlign: "center",
+                      fontSize: 10,
+                      lineHeight: "16px",
+                      fontWeight: 600,
+                    }}
+                  >
+                    {xp} / {title === "MapMaster" ? xp : title === "MapExpert" ? "10000" : "5000"}
+                  </div>
+                </div>
+              </div>
+              <div
+                style={{
+                  marginTop: 4,
+                  padding: "4px 12px",
+                  backgroundColor:
+                    xp >= 10000 ? "#d4af37" :
+                      xp >= 5000 ? "#40a9ff" :
+                        "#73d13d",
+                  color: "#000",
+                  fontWeight: "bold",
+                  borderRadius: "999px",
+                  fontSize: "12px",
+                  textAlign: "center",
+                  display: "inline-block",
+                  boxShadow: "0 0 6px rgba(0,0,0,0.2)",
+                }}
               >
-                Logout
-              </Button>
-            </Tooltip>
-          </>
-        ) : (
-          <>
-            <Tooltip title="Login">
-              <Link href="/users/login">
-                <LoginOutlined
-                  style={{ fontSize: "24px", color: "#fff", cursor: "pointer" }}
-                  aria-label="Login"
-                />
-              </Link>
-            </Tooltip>
+                {title}
+              </div>
 
-            <Tooltip title="Register">
-              <Link href="/users/register">
-                <UserAddOutlined className="nav-icon" aria-label="Register" />
-              </Link>
-            </Tooltip>
-
-            <Tooltip title="Leaderboard">
-              <Link href="/leaderboard">
-                <TrophyOutlined className="nav-icon" aria-label="Leaderboard" />
-              </Link>
-            </Tooltip>
-          </>
-        )}
+            </div>
+          </div>
+        </Dropdown>
       </div>
     </nav>
   );
 }
+
+const menuItemStyle: React.CSSProperties = {
+  display: "flex",
+  alignItems: "center",
+  gap: 10,
+  backgroundColor: "transparent",
+  padding: "10px 12px",
+  borderRadius: 10,
+  fontSize: 14,
+  fontWeight: 500,
+  cursor: "pointer",
+  color: "#fff",
+  textDecoration: "none",
+  transition: "all 0.2s",
+};

--- a/app/styles/createForm.module.css
+++ b/app/styles/createForm.module.css
@@ -10,7 +10,6 @@
     color: #fff;
   }
   
-  /* 标题 */
   .createTitle {
     font-size: 1.3rem;
     font-weight: bold;
@@ -19,7 +18,6 @@
     text-align: center;
   }
   
-  /* 输入框和选择器统一风格 */
   .input {
     width: 100%;
     padding: 8px 12px;
@@ -30,7 +28,6 @@
     color: white;
   }
   
-  /* 提交按钮 */
   .createButton {
     width: 100%;
     padding: 10px 15px;
@@ -47,7 +44,6 @@
     background-color: #0284c7;
   }
   
-  /* 自定义 toggle switch 容器（可用在外部 Form.Item） */
   .switch {
     display: flex;
     align-items: center;
@@ -55,14 +51,12 @@
     height: 24px;
   }
   
-  /* 让 label 文字美观 */
   :global(.ant-form-item-label > label) {
     color: #ccc;
     font-size: 0.9rem;
     margin-bottom: 4px;
   }
   
-  /* 减少垂直间距（字段之间） */
   :global(.ant-form-item) {
     margin-bottom: 12px;
   }

--- a/app/styles/lobby.module.css
+++ b/app/styles/lobby.module.css
@@ -188,7 +188,7 @@
 
 .sidebarToggle {
   position: fixed;
-  top: 85px;
+  top: 110px;
   right: 0;
   background-color: #0ea5e9;
   color: white;

--- a/app/userSlice.ts
+++ b/app/userSlice.ts
@@ -33,7 +33,8 @@ interface UserState {
   currentGameMode: string | null; // "solo" or "combat"
   currentTeamId: string | null;
   gameResults: GameResults | null; // Store the last game result
-  isGuest: boolean; // To track if the user is a guest
+  avatar: string | null; // Avatar URL or path
+  level: number | null; // User level (e.g., "beginner", "intermediate", "expert")
 }
 
 // Initial state setup for both guest and registered users
@@ -48,7 +49,8 @@ const initialState: UserState = {
   currentGameMode: null,
   currentTeamId: null,
   gameResults: null, // Initially, there are no results
-  isGuest: true, // Initially, user is a guest
+  avatar: null, // Avatar URL or path
+  level: null, // User level (e.g., "beginner", "intermediate", "expert")
 };
 
 // Create the user slice
@@ -57,13 +59,14 @@ const userSlice = createSlice({
   initialState,
   reducers: {
     // Login action for registered users
-    login(state, action: PayloadAction<{ username: string; userId: string; token: string; status: string }>) {
+    login(state, action: PayloadAction<{ username: string; userId: string; token: string; status: string, avatar: string, level: number }>) {
       state.isLoggedIn = true;
       state.username = action.payload.username;
       state.userId = action.payload.userId;
       state.token = action.payload.token;
       state.status = action.payload.status;
-      state.isGuest = false;
+      state.avatar = action.payload.avatar; // Set avatar if provided
+      state.level = action.payload.level; // Set user level if provided
     },
     // Logout action to reset the user state
     logout(state) {
@@ -75,24 +78,16 @@ const userSlice = createSlice({
       state.gameHistory = [];
       state.learningProgress = [];
       state.gameResults = null; // Clear the game results
-      state.isGuest = true;
       state.currentGameMode = null;
       state.currentTeamId = null;
-    },
-    // Guest login (temporary user)
-    guestLogin(state) {
-      state.isLoggedIn = true;
-      state.isGuest = true;
-      state.userId = `guest-${Date.now()}`; // Create a unique guest ID based on timestamp
-      state.username = `Guest ${state.userId}`;
-      state.token = null; // No token for guests
-      state.status = "OFFLINE"; // Default status for guest
-      state.gameHistory = [];
-      state.learningProgress = [];
+      state.avatar = null; // Clear avatar
+      state.level = null; // Clear user level
     },
     // Update the user details (username, etc.)
-    updateUsername(state, action: PayloadAction<string>) {
-      state.username = action.payload;
+    updateUserInfo(state, action: PayloadAction<{ username: string, avatar: string, level: number }>) {
+      state.username = action.payload.username;
+      state.avatar = action.payload.avatar; // Set avatar if provided
+      state.level = action.payload.level; // Set user level if provided
     },
     // Update the user's game mode (solo or combat)
     setCurrentGameMode(state, action: PayloadAction<string | null>) {
@@ -134,16 +129,17 @@ const userSlice = createSlice({
       state.gameHistory = [];
       state.learningProgress = [];
       state.gameResults = null; // Clear the game results
-      state.isGuest = true;
       state.currentGameMode = null;
       state.currentTeamId = null;
+      state.avatar = null; // Clear avatar
+      state.level = null; // Clear user level
     },
   },
 });
 
 // Export actions for use in components
 export const { 
-  login, logout, guestLogin, updateUsername, setCurrentGameMode, 
+  login, logout, updateUserInfo, setCurrentGameMode, 
   addGameHistory, updateLearningProgress, setTeamId, setGameResults,
   clearUserState
 } = userSlice.actions;

--- a/app/users/login/page.tsx
+++ b/app/users/login/page.tsx
@@ -34,7 +34,9 @@ const Login: React.FC = () => {
             username: response.username ?? "",
             status: response.status ?? "",
             userId: response.userId.toString(),
-            token: response.token
+            token: response.token,
+            avatar: response.avatar ?? "",
+            level: Number(response.level) ?? 0,
           }));
         dispatch(clearGameState()); // Clear game state on login
   

--- a/app/users/profile/page.tsx
+++ b/app/users/profile/page.tsx
@@ -37,7 +37,7 @@ const ProfilePage = () => {
     };
 
     fetchUser();
-  }, [apiService]);
+  }, [apiService, userId, router]);
 
   const handleEdit = () => {
     setIsEditing(true);

--- a/app/users/profile/page.tsx
+++ b/app/users/profile/page.tsx
@@ -4,12 +4,14 @@ import { Input, Button, Form } from "antd";
 import { useApi } from "@/hooks/useApi";
 import { User } from "@/types/user"
 import { useRouter } from "next/navigation";
-import { useSelector } from "react-redux";
+import { useDispatch, useSelector } from "react-redux";
+import { updateUserInfo } from "@/userSlice";
 // import Authenticator from "@/auth/authenticator";
 
 const ProfilePage = () => {
   const router = useRouter();
   const apiService = useApi();
+  const dispatch = useDispatch();
   const userId = useSelector((state: { user: { userId: string } }) => state.user.userId);
   const token = useSelector((state: { user: { token: string } }) => state.user.token);
 
@@ -60,7 +62,11 @@ const ProfilePage = () => {
         }
       }
       setUser(updatedUser);
-      alert("Saved!");
+      dispatch(updateUserInfo({ 
+        username: updatedUser.username ?? "",
+        avatar: updatedUser.avatar ?? "",
+        level: Number(updatedUser.level) / 100,
+      }));
       setIsEditing(false);
     } catch (error) {
       if (error instanceof Error) {
@@ -144,7 +150,7 @@ const ProfilePage = () => {
                     )}
                   </Form.Item>
                 </Form.Item>
-                <Form.Item>
+                {/* <Form.Item>
                   {(() => {
                     const level = form.getFieldValue("level");
 
@@ -177,7 +183,7 @@ const ProfilePage = () => {
                       </div>
                     );
                   })()}
-                </Form.Item>
+                </Form.Item> */}
               </div>
               <Form.Item label="Username">
                 {isEditing ? (

--- a/app/users/register/page.tsx
+++ b/app/users/register/page.tsx
@@ -37,6 +37,8 @@ const Register: React.FC = () => {
             status: response.status ?? "OFFLINE",
             userId: response.userId.toString(),
             token: response.token,
+            avatar: response.avatar ?? "",
+            level: Number(response.level) ?? 0,
           })
         );
         dispatch(clearGameState()); // Clear game state on login

--- a/app/utils/useLogout.ts
+++ b/app/utils/useLogout.ts
@@ -33,7 +33,10 @@ export const useLogout = () => {
       await apiService.post<User>(`/logout`, { token: userToken });
 
       // Dispatch the logout action to reset Redux state
-      dispatch(logout());
+      setTimeout(() => {
+        dispatch(logout());
+      }
+      , 500);
 
       console.log("Logged out successfully!");
       router.push("/");


### PR DESCRIPTION
## Achievement
* add a deck to show user information directly on the `navbar`
* adjust the layout of `navbar`: put profile, history and statistics into a list which can be unfolded when clicking on the deck
* Once the user information are updated after the following two scenarios, the deck shows the latest results:
  * users edit their profiles
  * users get back from a game result

## Layout
![image](https://github.com/user-attachments/assets/cde090f1-ec37-48c6-90bb-f75f497e1f11)

Close #65 
